### PR TITLE
Add low level clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,31 +11,27 @@ import (
     "context"
     "fmt"
 
-    "github.com/deflix-tv/go-debrid"
     "github.com/deflix-tv/go-debrid/realdebrid"
-    "go.uber.org/zap"
 )
 
 func main() {
     // Create new client
-    rd, err := realdebrid.NewClient(realdebrid.DefaultClientOpts, debrid.NewInMemoryCache(), debrid.NewInMemoryCache(), zap.NewNop())
-    if err != nil {
-        panic(err)
-    }
-
     auth := realdebrid.Auth{KeyOrToken: "123"}
+    rd := realdebrid.NewClient(realdebrid.DefaultClientOpts, auth, nil)
+
     // We're using some info hashes of "Night of the Living Dead" from 1968, which is in the public domain
     infoHashes := []string{
         "50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139",
         "11EA02584FA6351956F35671962AB46354D99060",
     }
-    availableInfoHashes := rd.CheckInstantAvailability(context.Background(), auth, infoHashes...)
+    availabilities, _ := rd.GetInstantAvailability(context.Background(), infoHashes...)
 
-    // Iterate through the available info hashes and print them
-    for _, availableInfoHash := range availableInfoHashes {
-        fmt.Printf("Available info_hash: %v\n", availableInfoHash)
+    // Iterate through the available torrents and print their details
+    for hash, availability := range availabilities {
+        fmt.Printf("Hash: %v\nAvailability: %+v\n", hash, availability)
     }
 }
+
 ```
 
 For more detailed examples see [examples](examples).

--- a/alldebrid/client.go
+++ b/alldebrid/client.go
@@ -1,0 +1,184 @@
+package alldebrid
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/tidwall/gjson"
+	"go.uber.org/zap"
+)
+
+var zapDebridService = zap.String("debridService", "AllDebrid")
+
+// ClientOptions are options for the client.
+type ClientOptions struct {
+	// Base URL for HTTP requests. This will also be used when making a request to a link that's read from a AllDebrid response by replacing its base URL.
+	BaseURL string
+	// Timeout for HTTP requests
+	Timeout time.Duration
+	// Extra headers to set for HTTP requests
+	ExtraHeaders map[string]string
+}
+
+// DefaultClientOpts are ClientOptions with reasonable default values.
+var DefaultClientOpts = ClientOptions{
+	BaseURL: "https://api.alldebrid.com/v4",
+	Timeout: 5 * time.Second,
+}
+
+// Client represents a AllDebrid client.
+type Client struct {
+	opts       ClientOptions
+	apiKey     string
+	httpClient *http.Client
+	logger     *zap.Logger
+}
+
+// NewClient returns a new AllDebrid client.
+// The logger param can be nil.
+func NewClient(opts ClientOptions, apiKey string, logger *zap.Logger) *Client {
+	// Set default values
+	if opts.BaseURL == "" {
+		opts.BaseURL = DefaultClientOpts.BaseURL
+	}
+	if opts.Timeout == 0 {
+		opts.Timeout = DefaultClientOpts.Timeout
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &Client{
+		opts:   opts,
+		apiKey: apiKey,
+		httpClient: &http.Client{
+			Timeout: opts.Timeout,
+		},
+		logger: logger,
+	}
+}
+
+// GetUser fetches and returns the user object from AllDebrid.
+func (c *Client) GetUser(ctx context.Context) (User, error) {
+	c.logger.Debug("Getting user...", zapDebridService)
+
+	resBytes, err := c.get(ctx, c.opts.BaseURL+"/user")
+	if err != nil {
+		return User{}, fmt.Errorf("couldn't get user: %w", err)
+	}
+	if gjson.GetBytes(resBytes, "status").String() != "success" {
+		errorCode := gjson.GetBytes(resBytes, "error.message").String()
+		return User{}, fmt.Errorf("got error response from AllDebrid: %v", errorCode)
+	}
+	userJSON := gjson.GetBytes(resBytes, "data.user").Raw
+	user := User{}
+	if err = json.Unmarshal([]byte(userJSON), &user); err != nil {
+		return User{}, fmt.Errorf("couldn't unmarshal user: %w", err)
+	}
+
+	c.logger.Debug("Got user", zap.String("user", fmt.Sprintf("%+v", user)), zapDebridService)
+	return user, nil
+}
+
+// Unlock unlocks a link.
+// For torrents, the torrent must first be added to AllDebrid, which then leads to such a hoster link (either instantly or after it was downloaded by AllDebrid).
+func (c *Client) Unlock(ctx context.Context, link string) (Download, error) {
+	c.logger.Debug("Unlocking link...", zapDebridService)
+
+	resBytes, err := c.get(ctx, c.opts.BaseURL+"/link/unlock?link="+url.QueryEscape(link))
+	if err != nil {
+		return Download{}, fmt.Errorf("couldn't unlock link: %w", err)
+	}
+	if gjson.GetBytes(resBytes, "status").String() != "success" {
+		errorCode := gjson.GetBytes(resBytes, "error.message").String()
+		return Download{}, fmt.Errorf("got error response from AllDebrid: %v", errorCode)
+	}
+	downloadJSON := gjson.GetBytes(resBytes, "data").Raw
+	dl := Download{}
+	if err = json.Unmarshal([]byte(downloadJSON), &dl); err != nil {
+		return Download{}, fmt.Errorf("couldn't unmarshal download: %w", err)
+	}
+
+	c.logger.Debug("Unlocked link", zap.String("download", fmt.Sprintf("%+v", dl)), zapDebridService)
+	return dl, nil
+}
+
+// UploadMagnet adds a torrent to AllDebrid via magnet URL.
+// The magnet string can actually also be a hash.
+func (c *Client) UploadMagnet(ctx context.Context, magnet string) (Magnet, error) {
+	c.logger.Debug("Uploading magnet...", zapDebridService)
+
+	data := url.Values{}
+	data.Set("magnets[]", magnet)
+	resBytes, err := c.post(ctx, c.opts.BaseURL+"/magnet/upload", data)
+	if err != nil {
+		return Magnet{}, fmt.Errorf("couldn't upload magnet: %w", err)
+	}
+	if gjson.GetBytes(resBytes, "status").String() != "success" {
+		errorCode := gjson.GetBytes(resBytes, "error.message").String()
+		return Magnet{}, fmt.Errorf("got error response from AllDebrid: %v", errorCode)
+	}
+	magnetJSON := gjson.GetBytes(resBytes, "data.magnets.0").Raw
+	m := Magnet{}
+	if err = json.Unmarshal([]byte(magnetJSON), &m); err != nil {
+		return Magnet{}, fmt.Errorf("couldn't unmarshal magnet: %w", err)
+	}
+
+	c.logger.Debug("Uploaded magnet", zap.String("magnet", fmt.Sprintf("%+v", m)), zapDebridService)
+	return m, nil
+}
+
+// GetStatus fetches and returns the status of a torrent that was added to AllDebrid for a specific user.
+// The ID must be the one returned from AllDebrid when adding the torrent to AllDebrid.
+func (c *Client) GetStatus(ctx context.Context, id int) (Status, error) {
+	c.logger.Debug("Getting status...", zapDebridService)
+
+	resBytes, err := c.get(ctx, c.opts.BaseURL+"/magnet/status?id="+strconv.Itoa(id))
+	if err != nil {
+		return Status{}, fmt.Errorf("couldn't get status: %w", err)
+	}
+	if gjson.GetBytes(resBytes, "status").String() != "success" {
+		errorCode := gjson.GetBytes(resBytes, "error.message").String()
+		return Status{}, fmt.Errorf("got error response from AllDebrid: %v", errorCode)
+	}
+	statusJSON := gjson.GetBytes(resBytes, "data.magnets").Raw
+	status := Status{}
+	if err = json.Unmarshal([]byte(statusJSON), &status); err != nil {
+		return Status{}, fmt.Errorf("couldn't unmarshal status: %w", err)
+	}
+
+	c.logger.Debug("Got status", zap.String("status", fmt.Sprintf("%+v", status)), zapDebridService)
+	return status, nil
+}
+
+// GetInstantAvailability fetches and returns info about the instant availability of a torrent.
+// The hashes can actually also be magnet URLs.
+// The returned map contains the hashes / magnet URLs of the torrents that are instantly available.
+func (c *Client) GetInstantAvailability(ctx context.Context, hashes ...string) (map[string]struct{}, error) {
+	c.logger.Debug("Getting instant availability...", zapDebridService)
+
+	data := url.Values{"magnets[]": hashes}
+	resBytes, err := c.post(ctx, c.opts.BaseURL+"/magnet/instant", data)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get instant availability: %w", err)
+	}
+	if gjson.GetBytes(resBytes, "status").String() != "success" {
+		errorCode := gjson.GetBytes(resBytes, "error.message").String()
+		return nil, fmt.Errorf("got error response from AllDebrid: %v", errorCode)
+	}
+	availabilities := make(map[string]struct{}, len(hashes))
+	gjson.GetBytes(resBytes, "data.magnets").ForEach(func(key, value gjson.Result) bool {
+		if value.Get("instant").Bool() {
+			availabilities[value.Get("magnet").String()] = struct{}{}
+		}
+		return true
+	})
+
+	c.logger.Debug("Got instant availability", zap.String("availabilities", fmt.Sprintf("%+v", availabilities)), zapDebridService)
+	return availabilities, nil
+}

--- a/alldebrid/client_test.go
+++ b/alldebrid/client_test.go
@@ -1,0 +1,67 @@
+package alldebrid_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deflix-tv/go-debrid/alldebrid"
+)
+
+// Night of the Living Dead, 1968, public domain (so legal to download, stream and share), from YTS
+var (
+	nightOfTheLivingDeadHash   = "50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139"
+	nightOfTheLivingDeadMagnet = "magnet:?xt=urn:btih:50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139&dn=Night+of+the+Living+Dead+%281968%29+%5B720p%5D+%5BYTS.MX%5D&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fp4p.arenabg.ch%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=http%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce"
+)
+
+func TestClient(t *testing.T) {
+	apiKey, ok := os.LookupEnv("AD_APIKEY")
+	require.True(t, ok, "API key is missing from the environment")
+
+	// Create client
+	client := alldebrid.NewClient(alldebrid.DefaultClientOpts, apiKey, nil)
+
+	ctx := context.Background()
+
+	// Get user
+	user, err := client.GetUser(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, user.Username)
+	require.NotEmpty(t, user.PremiumUntil)
+
+	// Get instant availability
+	availabilities, err := client.GetInstantAvailability(ctx, nightOfTheLivingDeadHash)
+	require.NoError(t, err)
+	fmt.Printf("Availabilities: %+v\n", availabilities)
+	// We assume that the torrent is instantly available when this test runs.
+	// If it's not, download it to AD so that it's available afterwards, or use a different torrent, then run the test again.
+	require.NotEmpty(t, len(availabilities))
+	_, found := availabilities[nightOfTheLivingDeadHash]
+	require.True(t, found)
+
+	// Upload magnet
+	magnet, err := client.UploadMagnet(ctx, nightOfTheLivingDeadMagnet)
+	require.NoError(t, err)
+	fmt.Printf("ID: %v\n", magnet.ID)
+	require.NotEmpty(t, magnet.ID)
+
+	// Get torrent info
+	status, err := client.GetStatus(ctx, magnet.ID)
+	require.NoError(t, err)
+	fmt.Printf("Torrent status: %+v\n", status)
+	require.NotEmpty(t, status.ID)
+	require.Equal(t, alldebrid.StatusCode_Ready, status.StatusCode)
+
+	link, err := alldebrid.SelectLargestFile(status)
+	require.NoError(t, err)
+	require.NotEmpty(t, link)
+
+	// Get HTTP download URL
+	dl, err := client.Unlock(ctx, link)
+	require.NoError(t, err)
+	fmt.Printf("Download: %+v\n", dl)
+	require.NotEmpty(t, dl.Link)
+}

--- a/alldebrid/http.go
+++ b/alldebrid/http.go
@@ -1,0 +1,88 @@
+package alldebrid
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+func (c *Client) get(ctx context.Context, url string) ([]byte, error) {
+	if strings.Contains(url, "?") {
+		url += "&agent=go-debrid&apikey=" + c.apiKey
+	} else {
+		url += "?agent=go-debrid&apikey=" + c.apiKey
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create GET request: %w", err)
+	}
+
+	for headerKey, headerVal := range c.opts.ExtraHeaders {
+		req.Header.Add(headerKey, headerVal)
+	}
+
+	c.logger.Debug("Sending request", zap.String("request", fmt.Sprintf("%+v", req)), zapDebridService)
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't send GET request: %w", err)
+	}
+	defer res.Body.Close()
+	resBody, err := ioutil.ReadAll(res.Body)
+	c.logger.Debug("Got response", zap.Int("status", res.StatusCode), zap.NamedError("bodyReadError", err), zap.ByteString("response", resBody), zapDebridService)
+
+	// Check server response status
+	if res.StatusCode != http.StatusOK {
+		if err, found := errMap[res.StatusCode]; found {
+			return resBody, err
+		}
+		// resBody can be nil if above ioutil.ReadAll failed, but in that case we don't care about the related error.
+		return resBody, fmt.Errorf("bad HTTP response status: %v", res.Status)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read response body: %w", err)
+	}
+	return resBody, nil
+}
+
+func (c *Client) post(ctx context.Context, url string, data url.Values) ([]byte, error) {
+	url += "?agent=go-debrid&apikey=" + c.apiKey
+	req, err := http.NewRequest("POST", url, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create POST request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for headerKey, headerVal := range c.opts.ExtraHeaders {
+		req.Header.Add(headerKey, headerVal)
+	}
+
+	c.logger.Debug("Sending request", zap.String("request", fmt.Sprintf("%+v", req)), zapDebridService)
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't send POST request: %w", err)
+	}
+	defer res.Body.Close()
+	resBody, err := ioutil.ReadAll(res.Body)
+	c.logger.Debug("Got response", zap.Int("status", res.StatusCode), zap.NamedError("bodyReadError", err), zap.ByteString("response", resBody), zapDebridService)
+
+	// Check server response.
+	// Different RealDebrid API POST endpoints return different status codes.
+	if res.StatusCode != http.StatusOK {
+		if err, found := errMap[res.StatusCode]; found {
+			return resBody, err
+		}
+		// resBody can be nil if above ioutil.ReadAll failed, but in that case we don't care about the related error.
+		return resBody, fmt.Errorf("bad HTTP response status: %v", res.Status)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read response body: %w", err)
+	}
+	return resBody, nil
+}

--- a/alldebrid/legacy.go
+++ b/alldebrid/legacy.go
@@ -18,29 +18,20 @@ import (
 	debrid "github.com/deflix-tv/go-debrid"
 )
 
-type ClientOptions struct {
+type LegacyClientOptions struct {
 	BaseURL      string
 	Timeout      time.Duration
 	CacheAge     time.Duration
 	ExtraHeaders []string
 }
 
-func NewClientOpts(baseURL string, timeout, cacheAge time.Duration, extraHeaders []string) ClientOptions {
-	return ClientOptions{
-		BaseURL:      baseURL,
-		Timeout:      timeout,
-		CacheAge:     cacheAge,
-		ExtraHeaders: extraHeaders,
-	}
-}
-
-var DefaultClientOpts = ClientOptions{
+var DefaultLegacyClientOpts = LegacyClientOptions{
 	BaseURL:  "https://api.alldebrid.com",
 	Timeout:  5 * time.Second,
 	CacheAge: 24 * time.Hour,
 }
 
-type Client struct {
+type LegacyClient struct {
 	baseURL    string
 	httpClient *http.Client
 	// For API key validity
@@ -52,7 +43,7 @@ type Client struct {
 	logger            *zap.Logger
 }
 
-func NewClient(opts ClientOptions, apiKeyCache, availabilityCache debrid.Cache, logger *zap.Logger) (*Client, error) {
+func NewLegacyClient(opts LegacyClientOptions, apiKeyCache, availabilityCache debrid.Cache, logger *zap.Logger) (*LegacyClient, error) {
 	// Precondition check
 	if opts.BaseURL == "" {
 		return nil, errors.New("opts.BaseURL must not be empty")
@@ -74,7 +65,7 @@ func NewClient(opts ClientOptions, apiKeyCache, availabilityCache debrid.Cache, 
 		}
 	}
 
-	return &Client{
+	return &LegacyClient{
 		baseURL: opts.BaseURL,
 		httpClient: &http.Client{
 			Timeout: opts.Timeout,
@@ -87,7 +78,7 @@ func NewClient(opts ClientOptions, apiKeyCache, availabilityCache debrid.Cache, 
 	}, nil
 }
 
-func (c *Client) TestAPIkey(ctx context.Context, apiKey string) error {
+func (c *LegacyClient) TestAPIkey(ctx context.Context, apiKey string) error {
 	zapFieldDebridSite := zap.String("debridSite", "AllDebrid")
 	zapFieldAPIkey := zap.String("apiKey", apiKey)
 	c.logger.Debug("Testing API key...", zapFieldDebridSite, zapFieldAPIkey)
@@ -126,7 +117,7 @@ func (c *Client) TestAPIkey(ctx context.Context, apiKey string) error {
 	return nil
 }
 
-func (c *Client) CheckInstantAvailability(ctx context.Context, apiKey string, infoHashes ...string) []string {
+func (c *LegacyClient) CheckInstantAvailability(ctx context.Context, apiKey string, infoHashes ...string) []string {
 	zapFieldDebridSite := zap.String("debridSite", "AllDebrid")
 	zapFieldAPItoken := zap.String("apiKey", apiKey)
 
@@ -220,7 +211,7 @@ func (c *Client) CheckInstantAvailability(ctx context.Context, apiKey string, in
 	return result
 }
 
-func (c *Client) GetStreamURL(ctx context.Context, magnetURL, apiKey string) (string, error) {
+func (c *LegacyClient) GetStreamURL(ctx context.Context, magnetURL, apiKey string) (string, error) {
 	zapFieldDebridSite := zap.String("debridSite", "AllDebrid")
 	zapFieldAPIkey := zap.String("apiKey", apiKey)
 	c.logger.Debug("Adding magnet to AllDebrid...", zapFieldDebridSite, zapFieldAPIkey)
@@ -284,7 +275,7 @@ func (c *Client) GetStreamURL(ctx context.Context, magnetURL, apiKey string) (st
 	return streamURL, nil
 }
 
-func (c *Client) get(ctx context.Context, url, apiKey string) ([]byte, error) {
+func (c *LegacyClient) get(ctx context.Context, url, apiKey string) ([]byte, error) {
 	if strings.Contains(url, "?") {
 		url += "&agent=deflix&apikey=" + apiKey
 	} else {
@@ -320,7 +311,7 @@ func (c *Client) get(ctx context.Context, url, apiKey string) ([]byte, error) {
 	return ioutil.ReadAll(res.Body)
 }
 
-func (c *Client) post(ctx context.Context, url, apiKey string, data url.Values) ([]byte, error) {
+func (c *LegacyClient) post(ctx context.Context, url, apiKey string, data url.Values) ([]byte, error) {
 	url += "?agent=deflix&apikey=" + apiKey
 	req, err := http.NewRequest("POST", url, strings.NewReader(data.Encode()))
 	if err != nil {

--- a/alldebrid/types.go
+++ b/alldebrid/types.go
@@ -1,0 +1,172 @@
+package alldebrid
+
+import (
+	"errors"
+)
+
+var (
+	// Bad request.
+	// Corresponds to AllDebrid 400 status code.
+	ErrorBadRequest = errors.New("bad request")
+	// Authentication error.
+	// Corresponds to AllDebrid 401 status code.
+	ErrorUnauthorized = errors.New("unauthorized")
+	// Too many requests hit the API too quickly, see https://docs.alldebrid.com/#rate-limiting.
+	// Corresponds to AllDebrid 429 status code.
+	ErrorTooManyRequests = errors.New("too many requests")
+	// Something went wrong on Alldebrid's end.
+	// Corresponds to AllDebrid 500, 502, 503 and 504 status codes.
+	ErrorServerError = errors.New("server error")
+)
+
+// TODO: Add error vars for the endpoint-specific errors, where the error codes are part of the HTTP response body, like "LINK_HOST_NOT_SUPPORTED" when trying to unlock a link.
+
+var errMap = map[int]error{
+	400: ErrorBadRequest,
+	401: ErrorUnauthorized,
+	429: ErrorTooManyRequests,
+	500: ErrorServerError,
+	502: ErrorServerError,
+	503: ErrorServerError,
+	504: ErrorServerError,
+}
+
+// User represents an AllDebrid user.
+type User struct {
+	// User username
+	Username string `json:"username"`
+	// User email
+	Email string `json:"email"`
+	// true is premium, false if not
+	IsPremium bool `json:"isPremium"`
+	// true is user has active subscription, false if not
+	IsSubscribed bool `json:"isSubscribed"`
+	// true is account is in freedays trial, false if not
+	IsTrial bool `json:"isTrial"`
+	// 0 if user is not premium, or timestamp until user is premium
+	PremiumUntil int `json:"premiumUntil"`
+	// Language used by the user on Alldebrid, eg. 'en', 'fr'. Default to fr
+	Lang string `json:"lang"`
+	// Preferer TLD used by the user, eg. 'fr', 'es'. Default to fr
+	PreferredDomain string `json:"preferedDomain"`
+	// Number of fidelity points
+	FidelityPoints int `json:"fidelityPoints"`
+	// Remaining quotas for the limited hosts (in MB)
+	LimitedHostersQuotas map[string]int `json:"limitedHostersQuotas"`
+	// When in trial mode, remaining global traffic quota available (in MB)
+	RemainingTrialQuota int `json:"remainingTrialQuota,omitempty"`
+}
+
+// Download represents an unlocked link.
+type Download struct {
+	// Requested link, simplified if it was not in canonical form
+	Link string `json:"link,omitempty"`
+	// Link's file filename
+	Filename string `json:"filename,omitempty"`
+	// Link host minified
+	Host string `json:"host,omitempty"`
+	// List of alternative links with other resolutions for some video links
+	Streams []Stream `json:"streams,omitempty"`
+	// Unused
+	Paws bool `json:"paws,omitempty"`
+	// Filesize of the link's file
+	Filesize int `json:"filesize,omitempty"`
+	// Generation ID
+	ID string `json:"id,omitempty"`
+	// Matched host main domain
+	HostDomain string `json:"hostDomain,omitempty"`
+	// Delayed ID if link need time to generate
+	Delayed int `json:"delayed,omitempty"`
+}
+
+// Stream is an alternative stream with a different resolution than the original one.
+type Stream struct {
+	// Resolution, e.g. `480` if the resolution is 480p.
+	Quality int `json:"quality,omitempty"`
+	// E.g. "mp4"
+	Ext string `json:"ext,omitempty"`
+	// File size in bytes
+	Filesize int    `json:"filesize,omitempty"`
+	Name     string `json:"name,omitempty"`
+	// Streamable direct link to the file
+	Link string `json:"link,omitempty"`
+	ID   string `json:"id,omitempty"`
+}
+
+// Magnet represents a magnet that was added to AllDebrid.
+type Magnet struct {
+	// Magnet sent
+	Magnet string `json:"magnet,omitempty"`
+	// Magnet filename, or 'noname' if could not parse it
+	Name string `json:"name,omitempty"`
+	// Magnet id, used to query status
+	ID int `json:"id,omitempty"`
+	// Magnet hash
+	Hash string `json:"hash,omitempty"`
+	// Magnet files size
+	Size int `json:"size,omitempty"`
+	// Whether the magnet is already available
+	Ready bool `json:"ready,omitempty"`
+}
+
+// Status contains status info about a torrent that was previously uploaded to AllDebrid for a specific user.
+type Status struct {
+	// Magnet id
+	ID int `json:"id,omitempty"`
+	// Magnet filename
+	Filename string `json:"filename,omitempty"`
+	// Magnet filesize
+	Size int `json:"size,omitempty"`
+	// Status in plain English
+	Status string `json:"status,omitempty"`
+	// Status code
+	StatusCode StatusCode `json:"statusCode,omitempty"`
+	// Downloaded data so far
+	Downloaded int `json:"downloaded,omitempty"`
+	// Uploaded data so far
+	Uploaded int `json:"uploaded,omitempty"`
+	// Seeders count
+	Seeders int `json:"seeders,omitempty"`
+	// Download speed
+	DownloadSpeed int `json:"downloadSpeed,omitempty"`
+	// Upload speed
+	UploadSpeed int `json:"uploadSpeed,omitempty"`
+	// Timestamp of the date of the magnet upload
+	UploadDate int `json:"uploadDate,omitempty"`
+	// Timestamp of the date of the magnet completion
+	CompletionDate int `json:"completionDate,omitempty"`
+	// an array of link objects
+	Links []Link `json:"links,omitempty"`
+	// files array format
+	Version int `json:"version,omitempty"`
+}
+
+// StatusCode indicates in which status an added torrent is.
+type StatusCode int
+
+const (
+	StatusCode_InQueue StatusCode = iota
+	StatusCode_Downloading
+	StatusCode_CompressingMoving
+	StatusCode_Uploading
+	StatusCode_Ready
+	StatusCode_UploadFail
+	StatusCode_InternalErrorOnUnpacking
+	StatusCode_NotDownloadedIn20Min
+	StatusCode_FileTooBig
+	StatusCode_InternalError
+	StatusCode_DownloadTookMoreThan72h
+	StatusCode_DeletedOnTheHosterWebsite
+)
+
+// Link represents a file in a torrent.
+type Link struct {
+	// Download link
+	Link string `json:"link,omitempty"`
+	// File name
+	Filename string `json:"filename,omitempty"`
+	// File size
+	Size int `json:"size,omitempty"`
+	// different format depending of version property
+	Files []interface{} `json:"files,omitempty"`
+}

--- a/alldebrid/util.go
+++ b/alldebrid/util.go
@@ -1,0 +1,21 @@
+package alldebrid
+
+import "errors"
+
+// SelectLargestFile returns the link of the largest file in the torrent.
+func SelectLargestFile(status Status) (string, error) {
+	var largestLink string
+	largestSize := 0
+
+	for _, link := range status.Links {
+		if link.Size > largestSize {
+			largestLink = link.Link
+			largestSize = link.Size
+		}
+	}
+	if largestLink == "" {
+		return "", errors.New("couldn't find largest file in status")
+	}
+
+	return largestLink, nil
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+## Debrid APIs
+
+For working with the APIs of RealDebrid, AllDebrid and Premiumize, it's useful to know how the basic HTTP requests and responses look like with real examples, apart from their API docs. Here we go through the APIs to show exactly these examples. It helps to quickly see how the JSON needs to be structured in order to access the fields etc.
+
+- [RealDebrid](api/RealDebrid.md)
+- [AllDebrid](api/AllDebrid.md)
+- [Premiumize](api/Premiumize.md)

--- a/docs/api/AllDebrid.md
+++ b/docs/api/AllDebrid.md
@@ -1,3 +1,236 @@
 # AllDebrid API
 
-TODO
+API docs: <https://docs.alldebrid.com>
+
+## Get your API key
+
+1. Login on <https://alldebrid.com/>
+2. Visit <https://alldebrid.com/apikeys>
+
+Store the key in a variable in the shell:
+
+```bash
+AD_APIKEY=...
+```
+
+## Get your user
+
+```bash
+curl --silent "https://api.alldebrid.com/v4/user?agent=myAppName&apikey=${AD_APIKEY}" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "user": {
+      "username": "yourusername",
+      "email": "foo@example.com",
+      "isPremium": true,
+      "isTrial": false,
+      "isSubscribed": false,
+      "premiumUntil": 123,
+      "lang": "en",
+      "preferedDomain": "com",
+      "fidelityPoints": 456,
+      "limitedHostersQuotas": {
+        "fileal": 2000,
+        "filespace": 2000,
+        "filefactory": 3000,
+        "gigapeta": 10000,
+        "videobin": 10000,
+        "isra": 3000,
+        "rapidgator": 50000,
+        "brupload": 3000,
+        "uploadcloud": 2000,
+        "userscloud": 3000,
+        "wipfiles": 3000,
+        "wdupload": 5000,
+        "ddl": 50000,
+        "flashbit": 5000,
+        "anzfile": 3000
+      }
+    }
+  }
+}
+```
+
+Using a bad API key doesn't lead to a non-"200 OK" response, but to a response body indicating the error:
+
+```json
+{
+  "status": "error",
+  "error": {
+    "code": "AUTH_BAD_APIKEY",
+    "message": "The auth apikey is invalid"
+  }
+}
+```
+
+## Check if a torrent is instantly available
+
+We use the torrent of the 720p version of "Night of the Living Dead" from 1968 from YTS. The movie is in the public domain, so it's legal to download, stream and share.
+
+Magnet: `magnet:?xt=urn:btih:50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139&dn=Night+of+the+Living+Dead+%281968%29+%5B720p%5D+%5BYTS.MX%5D&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fp4p.arenabg.ch%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=http%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce`
+
+=> Info hash: `50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139`
+
+Request:
+
+```bash
+curl --silent --form "magnets[]=50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139" "https://api.alldebrid.com/v4/magnet/instant?agent=myAppName&apikey=${AD_APIKEY}" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "magnets": [
+      {
+        "magnet": "50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139",
+        "hash": "50b7dafb7137cbecf045f78e8efbe4ac1a90d139",
+        "instant": true
+      }
+    ]
+  }
+}
+
+```
+
+Note that there's no differentiation between the files in the torrent. If a hash is available, all files are available.
+
+## Upload magnet URL
+
+We're using the same magnet URL as above, for "Night of the Living Dead", which is in the public domain.
+
+```bash
+curl --silent --form "magnets[]=magnet:?xt=urn:btih:50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139&dn=Night+of+the+Living+Dead+%281968%29+%5B720p%5D+%5BYTS.MX%5D&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fp4p.arenabg.ch%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=http%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce" "https://api.alldebrid.com/v4/magnet/upload?agent=myAppName&apikey=${AD_APIKEY}" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "magnets": [
+      {
+        "magnet": "magnet:?xt=urn:btih:50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139&dn=Night+of+the+Living+Dead+%281968%29+%5B720p%5D+%5BYTS.MX%5D&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fp4p.arenabg.ch%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=http%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce",
+        "hash": "50b7dafb7137cbecf045f78e8efbe4ac1a90d139",
+        "name": "Night of the Living Dead (1968) [720p] [YTS.MX]",
+        "filename_original": "",
+        "size": 828818888,
+        "ready": true,
+        "id": 456
+      }
+    ]
+  }
+}
+```
+
+## Get the status of a torrent
+
+Use the same ID we got from the previous step where we added the magnet URL, `"456"` in our example.
+
+```bash
+curl --silent --get --data-urlencode "id=456" "https://api.alldebrid.com/v4/magnet/status?agent=myAppName&apikey=${AD_APIKEY}" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "magnets": {
+      "id": 456,
+      "filename": "Night Of The Living Dead (1968) [BluRay] [720p] [YTS.AM]",
+      "size": 828818888,
+      "hash": "50b7dafb7137cbecf045f78e8efbe4ac1a90d139",
+      "status": "Ready",
+      "statusCode": 4,
+      "downloaded": 828818888,
+      "uploaded": 828818888,
+      "seeders": 0,
+      "downloadSpeed": 0,
+      "processingPerc": 0,
+      "uploadSpeed": 0,
+      "uploadDate": 1613926249,
+      "completionDate": 1613926249,
+      "links": [
+        {
+          "link": "https://uptobox.com/abc789",
+          "filename": "Night.Of.The.Living.Dead.1968.720p.BluRay.x264-[YTS.AM].mp4",
+          "size": 828760756,
+          "files": [
+            "Night.Of.The.Living.Dead.1968.720p.BluRay.x264-[YTS.AM].mp4"
+          ]
+        },
+        {
+          "link": "https://uptobox.com/def012",
+          "filename": "www.YTS.AM.jpg",
+          "size": 58132,
+          "files": [
+            "www.YTS.AM.jpg"
+          ]
+        }
+      ],
+      "type": "m",
+      "notified": true,
+      "version": 1
+    }
+  }
+}
+```
+
+Different from RealDebrid, where after adding a magnet the status is "waiting_files_selection" at first, here we directly get the `"status": "Ready"` as well as links for each file. The links are no direct download links though, they're like OCH hoster links (like uploaded.net, Rapidgator, Mega.nz), so we take another step with AllDebrid to get to the final direct download.
+
+## Generate HTTP download link
+
+We're using the URL form the `"links"` from the previous response, so `"https://uptobox.com/abc789"` in our example.
+
+```bash
+curl --silent --get --data-urlencode "link=https://uptobox.com/abc789" "https://api.alldebrid.com/v4/link/unlock?agent=myAppName&apikey=${AD_APIKEY}" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "link": "https://ghi.debrid.it/dl/345jkl/Night.Of.The.Living.Dead.1968.720p.BluRay.x264-%5BYTS.AM%5D.mp4",
+    "host": "uptobox",
+    "filename": "Night.Of.The.Living.Dead.1968.720p.BluRay.x264-[YTS.AM].mp4",
+    "streaming": [],
+    "paws": false,
+    "filesize": 828760756,
+    "streams": [
+      {
+        "quality": 480,
+        "ext": "mp4",
+        "filesize": 718147584,
+        "name": "und",
+        "link": "https://www12.uptostream.com/901pqr/480/0/video.mp4",
+        "id": "480-und"
+      },
+      {
+        "quality": 360,
+        "ext": "mp4",
+        "filesize": 451067904,
+        "name": "und",
+        "link": "https://www12.uptostream.com/901pqr/360/0/video.mp4",
+        "id": "360-und"
+      }
+    ],
+    "id": "678mno",
+    "hostDomain": "uptobox.com"
+  }
+}
+```
+
+The `"link"` URL is streamable and downloadable.

--- a/docs/api/AllDebrid.md
+++ b/docs/api/AllDebrid.md
@@ -1,0 +1,3 @@
+# AllDebrid API
+
+TODO

--- a/docs/api/Premiumize.md
+++ b/docs/api/Premiumize.md
@@ -1,3 +1,160 @@
 # Premiumize API
 
-TODO
+API docs: <https://app.swaggerhub.com/apis/premiumize.me/api>
+
+## Get your API key
+
+1. Login on <https://www.premiumize.me/>
+2. Visit <https://www.premiumize.me/account>
+
+Store the key in a variable in the shell:
+
+```bash
+PM_APIKEY=...
+```
+
+## Get your account info
+
+```bash
+curl --silent "https://www.premiumize.me/api/account/info?apikey=${PM_APIKEY}" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "status": "success",
+  "customer_id": "123",
+  "premium_until": 456,
+  "limit_used": 0,
+  "space_used": 789
+}
+```
+
+Using a bad API key doesn't lead to a non-"200 OK" response, but to a response body indicating the error:
+
+```json
+{
+  "status": "error",
+  "message": "customer_id and pin parameter missing or not logged in "
+}
+```
+
+## Check if a torrent is in the cache
+
+We use the torrent of the 720p version of "Night of the Living Dead" from 1968 from YTS. The movie is in the public domain, so it's legal to download, stream and share.
+
+Magnet: `magnet:?xt=urn:btih:50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139&dn=Night+of+the+Living+Dead+%281968%29+%5B720p%5D+%5BYTS.MX%5D&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fp4p.arenabg.ch%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=http%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce`
+
+=> Info hash: `50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139`
+
+Request:
+
+```bash
+curl --silent --get --data-urlencode "items[]=50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139" "https://www.premiumize.me/api/cache/check?apikey=${PM_APIKEY}" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "status": "success",
+  "response": [
+    true
+  ],
+  "transcoded": [
+    true
+  ],
+  "filename": [
+    "Night Of The Living Dead (1968) [BluRay] [720p] [YTS.AM]"
+  ],
+  "filesize": [
+    "828818888"
+  ]
+}
+```
+
+Note that there's no differentiation between the files in the torrent. If a hash is available, all files are available.
+
+## Create direct download link
+
+We're using the same magnet URL as above, for "Night of the Living Dead", which is in the public domain.
+
+Request:
+
+```bash
+curl --silent --data-urlencode "src=magnet:?xt=urn:btih:50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139&dn=Night+of+the+Living+Dead+%281968%29+%5B720p%5D+%5BYTS.MX%5D&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fp4p.arenabg.ch%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=http%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce" "https://www.premiumize.me/api/transfer/directdl?apikey=${PM_APIKEY}" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "status": "success",
+  "content": [
+    {
+      "path": "Night Of The Living Dead (1968) [BluRay] [720p] [YTS.AM]/www.YTS.AM.jpg",
+      "size": "58132",
+      "link": "https://jenny.plusnet.club/dl/abc012/345/678/def901.234/www.YTS.AM.jpg",
+      "stream_link": null,
+      "transcode_status": "not_applicable"
+    },
+    {
+      "path": "Night Of The Living Dead (1968) [BluRay] [720p] [YTS.AM]/Night.Of.The.Living.Dead.1968.720p.BluRay.x264-[YTS.AM].mp4",
+      "size": "828760756",
+      "link": "https://lyanna.lmklol.link/dl/ghi567-890jkl/345/678/mno123.321/Night.Of.The.Living.Dead.1968.720p.BluRay.x264-%5BYTS.AM%5D.mp4",
+      "stream_link": "https://lyanna.lmklol.link/dl/ghi567-890jkl/345/678/mno123.321/Night.Of.The.Living.Dead.1968.720p.BluRay.x264-%5BYTS.AM%5D.mp4",
+      "transcode_status": "good_as_is"
+    }
+  ]
+}
+```
+
+## Add a transfer
+
+When a magnet is not cached you can't use the request to create a direct download link. You first have to add a transfer.
+
+We're using the magnet URL of the torrent of the 1080p version for the same movie as above, "Night of the Living Dead", which is in the public domain.
+
+```bash
+curl --silent --data-urlencode "src=magnet:?xt=urn:btih:11EA02584FA6351956F35671962AB46354D99060&dn=Night+of+the+Living+Dead+%281968%29+%5B1080p%5D+%5BYTS.MX%5D&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fp4p.arenabg.ch%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=http%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce" "https://www.premiumize.me/api/transfer/create?apikey=${PM_APIKEY}" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "status": "success",
+  "type": "savetocloud",
+  "id": "xyz321",
+  "name": "Night of the Living Dead (1968) [1080p] [YTS.MX]"
+}
+```
+
+## Get info about the transfer
+
+```bash
+curl --silent "https://www.premiumize.me/api/transfer/list?apikey=${PM_APIKEY}" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "status": "success",
+  "transfers": [
+    {
+      "id": "xyz321-VREg",
+      "name": "Night Of The Living Dead (1968) [BluRay] [1080p] [YTS.AM]",
+      "message": null,
+      "status": "finished",
+      "progress": 0,
+      "folder_id": "-uvw654",
+      "file_id": null,
+      "src": "magnet:?xt=urn:btih:11ea02584fa6351956f35671962ab46354d99060&dn=Night+Of+The+Living+Dead+(1968)+BluRay+1080p+YTS+%5BYIFY%5D&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp://tracker.internetwarriors.net:1337&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969"
+    }
+  ]
+}
+```
+
+Note that the response contains *all* past transfers (except for the ones that were directly turned into a direct download link via the `/directdl` endpoint).

--- a/docs/api/Premiumize.md
+++ b/docs/api/Premiumize.md
@@ -1,0 +1,3 @@
+# Premiumize API
+
+TODO

--- a/docs/api/RealDebrid.md
+++ b/docs/api/RealDebrid.md
@@ -1,0 +1,210 @@
+# RealDebrid API
+
+API docs: <https://api.real-debrid.com>
+
+## Get your API key
+
+1. Login on <https://real-debrid.com>
+2. Visit <https://real-debrid.com/apitoken>
+
+Store the token in a variable in the shell:
+
+```bash
+RD_APITOKEN=...
+```
+
+## Get your user
+
+```bash
+curl --silent -H "Authorization: Bearer ${RD_APITOKEN}" "https://api.real-debrid.com/rest/1.0/user" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "id": 123,
+  "username": "yourusername",
+  "email": "foo*****@example.com",
+  "points": 456,
+  "locale": "en",
+  "avatar": "https://fcdn.real-debrid.com/images/forum/empty.png",
+  "type": "premium",
+  "premium": 789,
+  "expiration": "2021-02-20T12:34:56.000Z"
+}
+```
+
+## Check if a torrent is instantly available
+
+We use the torrent of the 720p version of "Night of the Living Dead" from 1968 from YTS. The movie is in the public domain, so it's legal to download, stream and share.
+
+Magnet: `magnet:?xt=urn:btih:50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139&dn=Night+of+the+Living+Dead+%281968%29+%5B720p%5D+%5BYTS.MX%5D&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fp4p.arenabg.ch%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=http%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce`
+
+=> Info hash: `50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139`
+
+Request:
+
+```bash
+curl --silent -H "Authorization: Bearer ${RD_APITOKEN}" "https://api.real-debrid.com/rest/1.0/torrents/instantAvailability/50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "50b7dafb7137cbecf045f78e8efbe4ac1a90d139": {
+    "rd": [
+      {
+        "1": {
+          "filename": "Night.Of.The.Living.Dead.1968.720p.BluRay.x264-[YTS.AM].mp4",
+          "filesize": 828760756
+        }
+      }
+    ]
+  }
+}
+```
+
+Note that there's only one file instantly available, while the torrent contains two files (the other one is the movie poster as jpg file).
+
+## Add magnet URL
+
+We're using the same magnet URL as above, for "Night of the Living Dead", which is in the public domain.
+
+```bash
+curl --silent -H "Authorization: Bearer ${RD_APITOKEN}" --data-urlencode magnet="magnet:?xt=urn:btih:50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139&dn=Night+of+the+Living+Dead+%281968%29+%5B720p%5D+%5BYTS.MX%5D&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fp4p.arenabg.ch%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=http%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce" "https://api.real-debrid.com/rest/1.0/torrents/addMagnet" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "id": "ABC123",
+  "uri": "https://api.real-debrid.com/rest/1.0/torrents/info/ABC123"
+}
+```
+
+## Get info about the torrent
+
+Use the same ID we got from the previous step where we added the magnet URL, "ABC123" in our example.
+
+```bash
+curl --silent -H "Authorization: Bearer ${RD_APITOKEN}" "https://api.real-debrid.com/rest/1.0/torrents/info/ABC123" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "id": "DEF456",
+  "filename": "Night Of The Living Dead (1968) [BluRay] [720p] [YTS.AM]",
+  "original_filename": "Night Of The Living Dead (1968) [BluRay] [720p] [YTS.AM]",
+  "hash": "50b7dafb7137cbecf045f78e8efbe4ac1a90d139",
+  "bytes": 828818888,
+  "original_bytes": 828818888,
+  "host": "real-debrid.com",
+  "split": 2000,
+  "progress": 0,
+  "status": "waiting_files_selection",
+  "added": "2021-02-20T12:33:31.000Z",
+  "files": [
+    {
+      "id": 1,
+      "path": "/Night.Of.The.Living.Dead.1968.720p.BluRay.x264-[YTS.AM].mp4",
+      "bytes": 828760756,
+      "selected": 0
+    },
+    {
+      "id": 2,
+      "path": "/www.YTS.AM.jpg",
+      "bytes": 58132,
+      "selected": 0
+    }
+  ],
+  "links": []
+}
+```
+
+Note the `"status": "waiting_files_selection"`, and also that the torrent contains two files, while in the instant availability check we got the info that only the first one is instantly available.
+
+## Add one of the files to the RealDebrid downloads
+
+The `files=1` selects the first file, and we use the same ID from the previous step, `DEF456` in our example.
+
+```bash
+curl --silent -H "Authorization: Bearer ${RD_APITOKEN}" --data-urlencode files=1 "https://api.real-debrid.com/rest/1.0/torrents/selectFiles/DEF456" | jq .
+```
+
+## Get info about the torrent *again*
+
+```bash
+curl --silent -H "Authorization: Bearer ${RD_APITOKEN}" "https://api.real-debrid.com/rest/1.0/torrents/info/DEF456" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "id": "DEF456",
+  "filename": "Night.Of.The.Living.Dead.1968.720p.BluRay.x264-[YTS.AM].mp4",
+  "original_filename": "Night Of The Living Dead (1968) [BluRay] [720p] [YTS.AM]",
+  "hash": "50b7dafb7137cbecf045f78e8efbe4ac1a90d139",
+  "bytes": 828760756,
+  "original_bytes": 828818888,
+  "host": "real-debrid.com",
+  "split": 2000,
+  "progress": 100,
+  "status": "downloaded",
+  "added": "2021-02-20T12:33:31.000Z",
+  "files": [
+    {
+      "id": 1,
+      "path": "/Night.Of.The.Living.Dead.1968.720p.BluRay.x264-[YTS.AM].mp4",
+      "bytes": 828760756,
+      "selected": 1
+    },
+    {
+      "id": 2,
+      "path": "/www.YTS.AM.jpg",
+      "bytes": 58132,
+      "selected": 0
+    }
+  ],
+  "links": [
+    "https://real-debrid.com/d/GHI789"
+  ],
+  "ended": "2019-10-28T21:18:16.000Z"
+}
+
+```
+
+Now it's `"status": "downloaded"` and there's a URL in `"links"`. Also, `"selected"` marks which file we previously selected for the download.
+
+## Generate HTTP download link
+
+We're using the URL form the `"links"` from the previous response, so `"https://real-debrid.com/d/GHI789"` in our example.
+
+```bash
+curl --silent -H "Authorization: Bearer ${RD_APITOKEN}" --data-urlencode "link=https://real-debrid.com/d/GHI789" "https://api.real-debrid.com/rest/1.0/unrestrict/link" | jq .
+```
+
+Should lead to something like:
+
+```json
+{
+  "id": "JKL012",
+  "filename": "Night.Of.The.Living.Dead.1968.720p.BluRay.x264-[YTS.AM].mp4",
+  "mimeType": "video/mp4",
+  "filesize": 828760756,
+  "link": "https://real-debrid.com/d/GHI789",
+  "host": "real-debrid.com",
+  "host_icon": "https://fcdn.real-debrid.com/123/images/hosters/realdebrid.png",
+  "chunks": 32,
+  "crc": 1,
+  "download": "https://123.download.real-debrid.com/d/JKL012/Night.Of.The.Living.Dead.1968.720p.BluRay.x264-%5BYTS.AM%5D.mp4",
+  "streamable": 1
+}
+```
+
+The `"download"` URL is streamable and downloadable.

--- a/examples/realdebrid/main.go
+++ b/examples/realdebrid/main.go
@@ -4,40 +4,32 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/deflix-tv/go-debrid"
 	"github.com/deflix-tv/go-debrid/realdebrid"
-	"go.uber.org/zap"
 )
 
 func main() {
 	// Prepare client parameters
 	opts := realdebrid.DefaultClientOpts
-	tokenCache := debrid.NewInMemoryCache()
-	availabilityCache := debrid.NewInMemoryCache()
-	logger, err := zap.NewDevelopment()
-	if err != nil {
-		panic(err)
-	}
+	auth := realdebrid.Auth{KeyOrToken: "123"}
 
 	// Create new client
-	rd, err := realdebrid.NewClient(opts, tokenCache, availabilityCache, logger)
-	if err != nil {
-		panic(err)
-	}
+	rd := realdebrid.NewClient(opts, auth, nil)
 
-	auth := realdebrid.Auth{KeyOrToken: "123"}
 	// We're using some info hashes of "Night of the Living Dead" from 1968, which is in the public domain
 	infoHashes := []string{
 		"50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139",
 		"11EA02584FA6351956F35671962AB46354D99060",
 	}
-	availableInfoHashes := rd.CheckInstantAvailability(context.Background(), auth, infoHashes...)
-	if len(availableInfoHashes) == 0 {
-		fmt.Println("None of the info hashes are available")
+	availabilities, err := rd.GetInstantAvailability(context.Background(), infoHashes...)
+	if err != nil {
+		panic(err)
+	}
+	if len(availabilities) == 0 {
+		fmt.Println("None of the torrents are available")
 	}
 
-	// Iterate through the available info hashes and print them
-	for _, availableInfoHash := range availableInfoHashes {
-		fmt.Printf("Available info_hash: %v\n", availableInfoHash)
+	// Iterate through the available torrents and print their details
+	for hash, availability := range availabilities {
+		fmt.Printf("Hash: %v\nAvailability: %+v\n", hash, availability)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/deflix-tv/go-debrid
 go 1.15
 
 require (
+	github.com/stretchr/testify v1.7.0
 	github.com/tidwall/gjson v1.6.7
 	go.uber.org/zap v1.16.0
 )

--- a/go.sum
+++ b/go.sum
@@ -15,10 +15,13 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tidwall/gjson v1.6.7 h1:Mb1M9HZCRWEcXQ8ieJo7auYyyiSux6w9XN3AdTpxJrE=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
@@ -57,5 +60,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=

--- a/premiumize/client.go
+++ b/premiumize/client.go
@@ -1,0 +1,212 @@
+package premiumize
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/tidwall/gjson"
+	"go.uber.org/zap"
+)
+
+var zapDebridService = zap.String("debridService", "Premiumize")
+
+// ClientOptions are options for the client.
+type ClientOptions struct {
+	// Base URL for HTTP requests. This will also be used when making a request to a link that's read from a Premiumize response by replacing its base URL.
+	BaseURL string
+	// Timeout for HTTP requests
+	Timeout time.Duration
+	// Extra headers to set for HTTP requests
+	ExtraHeaders map[string]string
+	// When setting this to true, the user's original IP address is read from Auth.IP and forwarded to Premiumize when creating a direct download links.
+	// Only required if the library is used in an app on a machine
+	// whose outgoing IP is different from the machine that's going to request the cached file/stream URL.
+	ForwardOriginIP bool
+}
+
+// DefaultClientOpts are ClientOptions with reasonable default values.
+var DefaultClientOpts = ClientOptions{
+	BaseURL: "https://www.premiumize.me/api",
+	Timeout: 5 * time.Second,
+}
+
+// Auth carries authentication/authorization info for Premiumize.
+type Auth struct {
+	// Long lasting API key or expiring OAuth2 access token
+	KeyOrToken string
+	// Flag for indicating whether KeyOrToken is a key (false) or token (true).
+	OAuth2 bool
+	// The user's original IP. Only required if ClientOptions.ForwardOriginIP is true.
+	IP string
+}
+
+// Client represents a Premiumize client.
+type Client struct {
+	opts       ClientOptions
+	auth       Auth
+	httpClient *http.Client
+	logger     *zap.Logger
+}
+
+// NewClient returns a new Premiumize client.
+// The logger param can be nil.
+func NewClient(opts ClientOptions, auth Auth, logger *zap.Logger) *Client {
+	// Set default values
+	if opts.BaseURL == "" {
+		opts.BaseURL = DefaultClientOpts.BaseURL
+	}
+	if opts.Timeout == 0 {
+		opts.Timeout = DefaultClientOpts.Timeout
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &Client{
+		opts: opts,
+		auth: auth,
+		httpClient: &http.Client{
+			Timeout: opts.Timeout,
+		},
+		logger: logger,
+	}
+}
+
+// CreateTransfer creates a transfer.
+// The source can be an HTTP(S) link to a supported container file, website or magnet link.
+// Transfers that are created this way will appear in the transfer list.
+func (c *Client) CreateTransfer(ctx context.Context, source string) (CreatedTransfer, error) {
+	c.logger.Debug("Creating transfer...", zapDebridService)
+
+	data := url.Values{}
+	data.Set("src", source)
+	resBytes, err := c.post(ctx, c.opts.BaseURL+"/transfer/create", data, true)
+	if err != nil {
+		return CreatedTransfer{}, fmt.Errorf("couldn't create transfer: %w", err)
+	}
+	if gjson.GetBytes(resBytes, "status").String() != "success" {
+		message := gjson.GetBytes(resBytes, "message").String()
+		return CreatedTransfer{}, fmt.Errorf("got error response from Premiumize: %v", message)
+	}
+	tf := CreatedTransfer{}
+	if err = json.Unmarshal(resBytes, &tf); err != nil {
+		return CreatedTransfer{}, fmt.Errorf("couldn't unmarshal added transfer: %w", err)
+	}
+
+	c.logger.Debug("Created transfer", zap.String("createdTransfer", fmt.Sprintf("%+v", tf)), zapDebridService)
+	return tf, nil
+}
+
+// CreateDDL creates direct download links.
+// The source can be an HTTP(S) link to a supported container file, website or magnet link.
+// The creation will only work if the file is cached on Premiumize or if a transfer for the file has been created before and the transfer finished downloading (to Premiumize).
+// If the source contains multiple files, each file is an element in the slice of Download objects.
+func (c *Client) CreateDDL(ctx context.Context, source string) ([]Download, error) {
+	c.logger.Debug("Creating direct download link...", zapDebridService)
+
+	data := url.Values{}
+	data.Set("src", source)
+	// Premiumize asks for the original IP only for directdl requests
+	if c.opts.ForwardOriginIP {
+		if c.auth.IP == "" {
+			return nil, errors.New("auth.IP is empty but client is configured to forward the user's original IP")
+		}
+		data.Add("download_ip", c.auth.IP)
+	}
+	resBytes, err := c.post(ctx, c.opts.BaseURL+"/transfer/directdl", data, true)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create direct download link: %w", err)
+	}
+	if gjson.GetBytes(resBytes, "status").String() != "success" {
+		message := gjson.GetBytes(resBytes, "message").String()
+		return nil, fmt.Errorf("got error response from Premiumize: %v", message)
+	}
+	downloadsJSON := gjson.GetBytes(resBytes, "content").Raw
+	downloads := []Download{}
+	if err = json.Unmarshal([]byte(downloadsJSON), &downloads); err != nil {
+		return nil, fmt.Errorf("couldn't unmarshal added transfer: %w", err)
+	}
+
+	c.logger.Debug("Created direct download link", zap.String("downloads", fmt.Sprintf("%+v", downloads)), zapDebridService)
+	return downloads, nil
+}
+
+// ListTransfers fetches and returns all transfers that were previously added to Premiumize for a specific user.
+// This doesn't include downloads that were created with CreateDDL without having been added via CreateTransfer.
+func (c *Client) ListTransfers(ctx context.Context) ([]Transfer, error) {
+	c.logger.Debug("Listing transfers...", zapDebridService)
+
+	resBytes, err := c.get(ctx, c.opts.BaseURL+"/transfer/list", nil)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't list transfers: %w", err)
+	}
+	if gjson.GetBytes(resBytes, "status").String() != "success" {
+		message := gjson.GetBytes(resBytes, "message").String()
+		return nil, fmt.Errorf("got error response from Premiumize: %v", message)
+	}
+	transferJSON := gjson.GetBytes(resBytes, "transfers").Raw
+	transfers := []Transfer{}
+	if err = json.Unmarshal([]byte(transferJSON), &transfers); err != nil {
+		return nil, fmt.Errorf("couldn't unmarshal transfer list: %w", err)
+	}
+
+	c.logger.Debug("Created direct download link", zap.String("transfers", fmt.Sprintf("%+v", transfers)), zapDebridService)
+	return transfers, nil
+}
+
+// GetAccountInfo fetches and returns info about the user's account.
+func (c *Client) GetAccountInfo(ctx context.Context) (AccountInfo, error) {
+	c.logger.Debug("Getting account info...", zapDebridService)
+
+	resBytes, err := c.get(ctx, c.opts.BaseURL+"/account/info", nil)
+	if err != nil {
+		return AccountInfo{}, fmt.Errorf("couldn't get account info: %w", err)
+	}
+	if gjson.GetBytes(resBytes, "status").String() != "success" {
+		message := gjson.GetBytes(resBytes, "message").String()
+		return AccountInfo{}, fmt.Errorf("got error response from Premiumize: %v", message)
+	}
+	accInfo := AccountInfo{}
+	if err = json.Unmarshal(resBytes, &accInfo); err != nil {
+		return AccountInfo{}, fmt.Errorf("couldn't unmarshal account info: %w", err)
+	}
+
+	c.logger.Debug("Got account info", zap.String("accountInfo", fmt.Sprintf("%+v", accInfo)), zapDebridService)
+	return accInfo, nil
+}
+
+// CheckCache checks if files are already in Premiumize's cache.
+// An item can be any link that Premiumize supports: Containers, direct links, magnet URLs, torrent info hashes.
+// The returned map contains only entries for cached files and uses the item as key.
+func (c *Client) CheckCache(ctx context.Context, items ...string) (map[string]CachedFile, error) {
+	c.logger.Debug("Checking cache...", zapDebridService)
+
+	data := url.Values{"items[]": items}
+	resBytes, err := c.get(ctx, c.opts.BaseURL+"/cache/check", data)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't check cache: %w", err)
+	}
+	if gjson.GetBytes(resBytes, "status").String() != "success" {
+		message := gjson.GetBytes(resBytes, "message").String()
+		return nil, fmt.Errorf("got error response from Premiumize: %v", message)
+	}
+	cachedFiles := make(map[string]CachedFile, len(items))
+	for i, item := range items {
+		if gjson.GetBytes(resBytes, "response."+strconv.Itoa(i)).Bool() {
+			cachedFiles[item] = CachedFile{
+				Transcoded: gjson.GetBytes(resBytes, "transcoded."+strconv.Itoa(i)).Bool(),
+				Filename:   gjson.GetBytes(resBytes, "filename."+strconv.Itoa(i)).String(),
+				Filesize:   gjson.GetBytes(resBytes, "filesize."+strconv.Itoa(i)).String(),
+			}
+		}
+	}
+
+	c.logger.Debug("Checked cache", zap.String("cachedFiles", fmt.Sprintf("%+v", cachedFiles)), zapDebridService)
+	return cachedFiles, nil
+}

--- a/premiumize/client_test.go
+++ b/premiumize/client_test.go
@@ -1,0 +1,79 @@
+package premiumize_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deflix-tv/go-debrid/premiumize"
+)
+
+// Night of the Living Dead, 1968, public domain (so legal to download, stream and share), from YTS
+var (
+	nightOfTheLivingDeadHash   = "50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139"
+	nightOfTheLivingDeadMagnet = "magnet:?xt=urn:btih:50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139&dn=Night+of+the+Living+Dead+%281968%29+%5B720p%5D+%5BYTS.MX%5D&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fp4p.arenabg.ch%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=http%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce"
+)
+
+func TestClient(t *testing.T) {
+	apiKey, ok := os.LookupEnv("PM_APIKEY")
+	require.True(t, ok, "API key is missing from the environment")
+
+	// Create client
+	auth := premiumize.Auth{
+		KeyOrToken: apiKey,
+	}
+	client := premiumize.NewClient(premiumize.DefaultClientOpts, auth, nil)
+
+	ctx := context.Background()
+
+	// Get account info
+	accInfo, err := client.GetAccountInfo(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, accInfo.CustomerID)
+	require.NotEmpty(t, accInfo.PremiumUntil)
+
+	// Check cache
+	cachedFiles, err := client.CheckCache(ctx, nightOfTheLivingDeadHash)
+	require.NoError(t, err)
+	fmt.Printf("Cached files: %+v\n", cachedFiles)
+	// We assume that the torrent is cached when this test runs.
+	// If it's not, download it to PM so that it's cached afterwards, or use a different torrent, then run the test again.
+	require.NotEmpty(t, len(cachedFiles))
+	cachedFile, found := cachedFiles[nightOfTheLivingDeadHash]
+	require.True(t, found)
+	require.NotEmpty(t, cachedFile.Filesize)
+
+	// Create transfer
+	createdTransfer, err := client.CreateTransfer(ctx, nightOfTheLivingDeadMagnet)
+	require.NoError(t, err)
+	fmt.Printf("ID: %v\n", createdTransfer.ID)
+	require.NotEmpty(t, createdTransfer.ID)
+
+	// List transfers
+	transfers, err := client.ListTransfers(ctx)
+	require.NoError(t, err)
+	fmt.Printf("Transfers: %+v\n", transfers)
+	require.NotEmpty(t, transfers)
+	var transfer premiumize.Transfer
+	for _, elem := range transfers {
+		if elem.ID == createdTransfer.ID {
+			transfer = elem
+			break
+		}
+	}
+	require.Equal(t, "finished", transfer.Status)
+
+	// Create direct download link
+	downloads, err := client.CreateDDL(ctx, transfer.Src)
+	require.NoError(t, err)
+	fmt.Printf("Downloads: %+v\n", downloads)
+	require.NotEmpty(t, downloads)
+
+	dl, err := premiumize.SelectLargestFile(downloads)
+	require.NoError(t, err)
+	fmt.Printf("Link: %+v\n", dl.Link)
+	require.NotEmpty(t, dl.Link)
+}

--- a/premiumize/http.go
+++ b/premiumize/http.go
@@ -1,0 +1,106 @@
+package premiumize
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+func (c *Client) get(ctx context.Context, urlString string, data url.Values) ([]byte, error) {
+	if c.auth.OAuth2 {
+		urlString += "?access_token=" + c.auth.KeyOrToken
+	} else {
+		urlString += "?apikey=" + c.auth.KeyOrToken
+	}
+
+	// map[string][]string
+	for k, vals := range data {
+		for _, val := range vals {
+			urlString += "&" + url.QueryEscape(k) + "=" + url.QueryEscape(val)
+		}
+	}
+
+	req, err := http.NewRequest("GET", urlString, nil)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create GET request: %w", err)
+	}
+	for headerKey, headerVal := range c.opts.ExtraHeaders {
+		req.Header.Add(headerKey, headerVal)
+	}
+
+	c.logger.Debug("Sending request", zap.String("request", fmt.Sprintf("%+v", req)), zapDebridService)
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't send GET request: %w", err)
+	}
+	defer res.Body.Close()
+	resBody, err := ioutil.ReadAll(res.Body)
+	c.logger.Debug("Got response", zap.Int("status", res.StatusCode), zap.NamedError("bodyReadError", err), zap.ByteString("response", resBody), zapDebridService)
+
+	// Check server response status
+	if res.StatusCode != http.StatusOK {
+		// resBody can be nil if above ioutil.ReadAll failed, but in that case we don't care about the related error.
+		return resBody, fmt.Errorf("bad HTTP response status: %v", res.Status)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read response body: %w", err)
+	}
+	return resBody, nil
+}
+
+func (c *Client) post(ctx context.Context, urlString string, data url.Values, form bool) ([]byte, error) {
+	if c.auth.OAuth2 {
+		urlString += "?access_token=" + c.auth.KeyOrToken
+	} else {
+		urlString += "?apikey=" + c.auth.KeyOrToken
+	}
+
+	var req *http.Request
+	var err error
+	if form {
+		req, err = http.NewRequest("POST", urlString, strings.NewReader(data.Encode()))
+	} else {
+		// map[string][]string
+		for k, vals := range data {
+			for _, val := range vals {
+				urlString += "&" + url.QueryEscape(k) + "=" + url.QueryEscape(val)
+			}
+		}
+		req, err = http.NewRequest("POST", urlString, nil)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create POST request: %w", err)
+	}
+	if form {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+	for headerKey, headerVal := range c.opts.ExtraHeaders {
+		req.Header.Add(headerKey, headerVal)
+	}
+
+	c.logger.Debug("Sending request", zap.String("request", fmt.Sprintf("%+v", req)), zapDebridService)
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't send POST request: %w", err)
+	}
+	defer res.Body.Close()
+	resBody, err := ioutil.ReadAll(res.Body)
+	c.logger.Debug("Got response", zap.Int("status", res.StatusCode), zap.NamedError("bodyReadError", err), zap.ByteString("response", resBody), zapDebridService)
+
+	// Check server response.
+	if res.StatusCode != http.StatusOK {
+		// resBody can be nil if above ioutil.ReadAll failed, but in that case we don't care about the related error.
+		return resBody, fmt.Errorf("bad HTTP response status: %v", res.Status)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read response body: %w", err)
+	}
+	return resBody, nil
+}

--- a/premiumize/legacy.go
+++ b/premiumize/legacy.go
@@ -21,7 +21,9 @@ type LegacyClientOptions struct {
 	Timeout      time.Duration
 	CacheAge     time.Duration
 	ExtraHeaders []string
-	// When setting this to true, the user's original IP address is read from the context parameter with the key "debrid_originIP".
+	// When setting this to true, the user's original IP address is read from Auth.IP and forwarded to Premiumize when creating a direct download links.
+	// Only required if the library is used in an app on a machine
+	// whose outgoing IP is different from the machine that's going to request the cached file/stream URL.
 	ForwardOriginIP bool
 }
 
@@ -78,17 +80,6 @@ func NewLegacyClient(opts LegacyClientOptions, apiKeyCache, availabilityCache de
 		forwardOriginIP:   opts.ForwardOriginIP,
 		logger:            logger,
 	}, nil
-}
-
-// Auth carries authentication/authorization info for Premiumize.
-type Auth struct {
-	// Long lasting API key or expiring OAuth2 access token
-	KeyOrToken string
-	// Flag for indicating whether KeyOrToken is an OAuth2 access token
-	OAUTH2 bool
-	// The user's original IP. Only required if the library is used in an app on a machine
-	// whose outgoing IP is different from the machine that's going to request the cached file/stream URL.
-	IP string
 }
 
 func (c *LegacyClient) TestAPIkey(ctx context.Context, auth Auth) error {
@@ -259,7 +250,7 @@ func (c *LegacyClient) GetStreamURL(ctx context.Context, magnetURL string, auth 
 }
 
 func (c *LegacyClient) get(ctx context.Context, url string, auth Auth) ([]byte, error) {
-	if auth.OAUTH2 {
+	if auth.OAuth2 {
 		url += "?access_token=" + auth.KeyOrToken
 	} else {
 		url += "?apikey=" + auth.KeyOrToken
@@ -292,7 +283,7 @@ func (c *LegacyClient) get(ctx context.Context, url string, auth Auth) ([]byte, 
 }
 
 func (c *LegacyClient) post(ctx context.Context, urlString string, auth Auth, data url.Values, form bool) ([]byte, error) {
-	if auth.OAUTH2 {
+	if auth.OAuth2 {
 		urlString += "?access_token=" + auth.KeyOrToken
 	} else {
 		urlString += "?apikey=" + auth.KeyOrToken

--- a/premiumize/types.go
+++ b/premiumize/types.go
@@ -1,0 +1,48 @@
+package premiumize
+
+// CreatedTransfer represents a transfer that has just been added to Premiumize.
+type CreatedTransfer struct {
+	Type string `json:"type,omitempty"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// Download represents a direct download. If a transfer was created by adding a torrent, a Download is a file in that torrent.
+type Download struct {
+	Path            string `json:"path,omitempty"`
+	Size            string `json:"size,omitempty"`
+	Link            string `json:"link,omitempty"`
+	StreamLink      string `json:"stream_link,omitempty"`
+	TranscodeStatus string `json:"transcode_status,omitempty"`
+}
+
+// Transfer represents a transfer, like a torrent that has been added to Premiumize for a specific user.
+type Transfer struct {
+	ID string `json:"id,omitempty"`
+	// Name of the torrent if the transfer was created by adding a torrent
+	Name    string `json:"name,omitempty"`
+	Message string `json:"message,omitempty"`
+	// "waiting", "finished" etc.
+	Status string `json:"status,omitempty"`
+	// Download progress. Can be 0 for cached files that don't have to be downloaded.
+	Progress float64 `json:"progress,omitempty"`
+	// When the transfer was created by adding a torrent via magnet URL, then this is the magnet URL
+	Src      string `json:"src,omitempty"`
+	FolderID string `json:"folder_id,omitempty"`
+	FileID   string `json:"file_id,omitempty"`
+}
+
+// AccountInfo contains info about a user account.
+type AccountInfo struct {
+	CustomerID   string  `json:"customer_id,omitempty"`
+	PremiumUntil int     `json:"premium_until,omitempty"`
+	LimitUsed    float64 `json:"limit_used,omitempty"`
+	SpaceUsed    float64 `json:"space_used,omitempty"`
+}
+
+// CachedFile represents a file that's available in Premiumize's cache.
+type CachedFile struct {
+	Transcoded bool
+	Filename   string
+	Filesize   string
+}

--- a/premiumize/util.go
+++ b/premiumize/util.go
@@ -1,0 +1,29 @@
+package premiumize
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+// SelectLargestFile returns the largest file in a slice of Download objects.
+func SelectLargestFile(downloads []Download) (Download, error) {
+	var result Download
+	largestSize := 0
+
+	for _, dl := range downloads {
+		size, err := strconv.Atoi(dl.Size)
+		if err != nil {
+			return Download{}, fmt.Errorf("couldn't parse size: %w", err)
+		}
+		if size > largestSize {
+			result = dl
+			largestSize = size
+		}
+	}
+	if largestSize == 0 {
+		return Download{}, errors.New("couldn't find largest file in downloads")
+	}
+
+	return result, nil
+}

--- a/realdebrid/client.go
+++ b/realdebrid/client.go
@@ -1,0 +1,213 @@
+package realdebrid
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+	"go.uber.org/zap"
+)
+
+var zapDebridService = zap.String("debridService", "RealDebrid")
+
+// ClientOptions are options for the client.
+type ClientOptions struct {
+	// Base URL for HTTP requests. This will also be used when making a request to a link that's read from a RealDebrid response by replacing its base URL.
+	BaseURL string
+	// Timeout for HTTP requests
+	Timeout time.Duration
+	// Extra headers to set for HTTP requests
+	ExtraHeaders map[string]string
+	// When setting this to true, the user's original IP address is read from Auth.IP and forwarded to RealDebrid for all POST requests.
+	// Only required if the library is used in an app on a machine
+	// whose outgoing IP is different from the machine that's going to request the cached file/stream URL.
+	ForwardOriginIP bool
+}
+
+// DefaultClientOpts are ClientOptions with reasonable default values.
+var DefaultClientOpts = ClientOptions{
+	BaseURL: "https://api.real-debrid.com/rest/1.0",
+	Timeout: 5 * time.Second,
+}
+
+// Auth carries authentication/authorization info for RealDebrid.
+type Auth struct {
+	// Long lasting API key or expiring OAuth2 access token
+	KeyOrToken string
+	// The user's original IP. Only required if ClientOptions.ForwardOriginIP is true.
+	IP string
+}
+
+// Client represents a RealDebrid client.
+type Client struct {
+	opts       ClientOptions
+	auth       Auth
+	httpClient *http.Client
+	logger     *zap.Logger
+}
+
+// NewClient returns a new RealDebrid client.
+// The logger param can be nil.
+func NewClient(opts ClientOptions, auth Auth, logger *zap.Logger) *Client {
+	// Set default values
+	if opts.BaseURL == "" {
+		opts.BaseURL = DefaultClientOpts.BaseURL
+	}
+	if opts.Timeout == 0 {
+		opts.Timeout = DefaultClientOpts.Timeout
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	return &Client{
+		opts: opts,
+		auth: auth,
+		httpClient: &http.Client{
+			Timeout: opts.Timeout,
+		},
+		logger: logger,
+	}
+}
+
+// GetUser fetches and returns the user object from RealDebrid.
+func (c *Client) GetUser(ctx context.Context) (User, error) {
+	c.logger.Debug("Getting user...", zapDebridService)
+
+	resBytes, err := c.get(ctx, c.opts.BaseURL+"/user")
+	if err != nil {
+		return User{}, fmt.Errorf("couldn't get user: %w", err)
+	}
+	user := User{}
+	if err = json.Unmarshal(resBytes, &user); err != nil {
+		return User{}, fmt.Errorf("couldn't unmarshal user: %w", err)
+	}
+
+	c.logger.Debug("Got user", zap.String("user", fmt.Sprintf("%+v", user)), zapDebridService)
+	return user, nil
+}
+
+// Unrestrict unrestricts a hoster link.
+// For torrents, the torrent must first be added to RealDebrid and a file selected for download, which then leads to such a hoster link.
+// When remote is true, account sharing restrictions are lifted, but it requires separately purchased "sharing traffic".
+func (c *Client) Unrestrict(ctx context.Context, link string, remote bool) (Download, error) {
+	c.logger.Debug("Unrestricting link...", zapDebridService)
+
+	data := url.Values{}
+	data.Set("link", link)
+	if remote {
+		data.Set("remote", "1")
+	}
+	resBytes, err := c.post(ctx, c.opts.BaseURL+"/unrestrict/link", data)
+	if err != nil {
+		return Download{}, fmt.Errorf("couldn't unrestrict link: %w", err)
+	}
+	dl := Download{}
+	if err = json.Unmarshal(resBytes, &dl); err != nil {
+		return Download{}, fmt.Errorf("couldn't unmarshal download: %w", err)
+	}
+
+	c.logger.Debug("Unrestricted link", zap.String("download", fmt.Sprintf("%+v", dl)), zapDebridService)
+	return dl, nil
+}
+
+// GetTorrentInfo fetches and returns info about a torrent that was added to RealDebrid for a specific user.
+// The ID must be the one returned from RealDebrid when adding the torrent to RealDebrid.
+func (c *Client) GetTorrentInfo(ctx context.Context, id string) (TorrentInfo, error) {
+	c.logger.Debug("Getting torrent info...", zapDebridService)
+
+	resBytes, err := c.get(ctx, c.opts.BaseURL+"/torrents/info/"+id)
+	if err != nil {
+		return TorrentInfo{}, fmt.Errorf("couldn't get torrent info: %w", err)
+	}
+	info := TorrentInfo{}
+	if err = json.Unmarshal(resBytes, &info); err != nil {
+		return TorrentInfo{}, fmt.Errorf("couldn't unmarshal torrent info: %w", err)
+	}
+
+	c.logger.Debug("Got torrent info", zap.String("torrentInfo", fmt.Sprintf("%+v", info)), zapDebridService)
+	return info, nil
+}
+
+// GetInstantAvailability fetches and returns info about the instant availability of a torrent.
+func (c *Client) GetInstantAvailability(ctx context.Context, hashes ...string) (map[string]InstantAvailability, error) {
+	c.logger.Debug("Getting instant availability...", zapDebridService)
+
+	var hashParams string
+	for _, hash := range hashes {
+		hashParams += "/" + hash
+	}
+	resBytes, err := c.get(ctx, c.opts.BaseURL+"/torrents/instantAvailability"+hashParams)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get instant availability: %w", err)
+	}
+	availabilities := make(map[string]InstantAvailability, len(hashes))
+	gjson.ParseBytes(resBytes).ForEach(func(key, value gjson.Result) bool {
+		availableHash := key.String()
+		// We check the original hash, so that our result has the same upper-/lowercase per hash
+		for _, hash := range hashes {
+			if strings.EqualFold(hash, availableHash) {
+				availableHash = hash
+				break
+			}
+		}
+		availability := InstantAvailability{}
+		value.Get("rd.0").ForEach(func(key, value gjson.Result) bool {
+			availableFile := AvailableFile{}
+			if err := json.Unmarshal([]byte(value.Raw), &availableFile); err != nil {
+				c.logger.Error("Couldn't unmarshal available file", zap.Error(err), zap.String("availableFile", value.Raw), zapDebridService)
+			}
+			availability[int(key.Int())] = availableFile
+			// Continue ForEach
+			return true
+		})
+		availabilities[availableHash] = availability
+		// Continue ForEach
+		return true
+	})
+
+	c.logger.Debug("Got instant availability", zap.String("availabilities", fmt.Sprintf("%+v", availabilities)), zapDebridService)
+	return availabilities, nil
+}
+
+// AddMagnet adds a torrent to RealDebrid via magnet URL.
+func (c *Client) AddMagnet(ctx context.Context, magnet string) (string, error) {
+	c.logger.Debug("Adding magnet...", zapDebridService)
+
+	data := url.Values{}
+	data.Set("magnet", magnet)
+	resBytes, err := c.post(ctx, c.opts.BaseURL+"/torrents/addMagnet", data)
+	if err != nil {
+		return "", fmt.Errorf("couldn't add magnet: %w", err)
+	}
+	id := gjson.GetBytes(resBytes, "id").String()
+
+	c.logger.Debug("Added magnet", zap.String("id", id), zapDebridService)
+	return id, nil
+}
+
+// SelectFiles starts downloading the selected files from a torrent that was previously added to RealDebrid for the specific user.
+func (c *Client) SelectFiles(ctx context.Context, torrentID string, fileIDs ...int) error {
+	c.logger.Debug("Selecting files...", zapDebridService)
+
+	data := url.Values{}
+	idStrings := make([]string, len(fileIDs))
+	for i, id := range fileIDs {
+		idStrings[i] = strconv.Itoa(id)
+	}
+	idString := strings.Join(idStrings, ",")
+	data.Set("files", idString)
+	_, err := c.post(ctx, c.opts.BaseURL+"/torrents/selectFiles/"+torrentID, data)
+	if err != nil {
+		return fmt.Errorf("couldn't select files: %w", err)
+	}
+
+	c.logger.Debug("Selected files", zapDebridService)
+	return nil
+}

--- a/realdebrid/client_test.go
+++ b/realdebrid/client_test.go
@@ -1,0 +1,89 @@
+package realdebrid_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deflix-tv/go-debrid/realdebrid"
+)
+
+// Night of the Living Dead, 1968, public domain (so legal to download, stream and share), from YTS
+var (
+	nightOfTheLivingDeadHash   = "50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139"
+	nightOfTheLivingDeadMagnet = "magnet:?xt=urn:btih:50B7DAFB7137CBECF045F78E8EFBE4AC1A90D139&dn=Night+of+the+Living+Dead+%281968%29+%5B720p%5D+%5BYTS.MX%5D&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fp4p.arenabg.ch%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=http%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce"
+)
+
+func TestClient(t *testing.T) {
+	apiKey, ok := os.LookupEnv("RD_APITOKEN")
+	require.True(t, ok, "API token is missing from the environment")
+
+	// Create client
+	auth := realdebrid.Auth{
+		KeyOrToken: apiKey,
+	}
+	client := realdebrid.NewClient(realdebrid.DefaultClientOpts, auth, nil)
+
+	ctx := context.Background()
+
+	// Get user
+	user, err := client.GetUser(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, user.ID)
+	require.NotEmpty(t, user.Premium)
+
+	// Get instant availability
+	availabilities, err := client.GetInstantAvailability(ctx, nightOfTheLivingDeadHash)
+	require.NoError(t, err)
+	fmt.Printf("Availabilities: %+v\n", availabilities)
+	// We assume that the torrent is instantly available when this test runs.
+	// If it's not, download it to RD so that it's available afterwards, or use a different torrent, then run the test again.
+	require.NotEmpty(t, len(availabilities))
+	availability, found := availabilities[nightOfTheLivingDeadHash]
+	require.True(t, found)
+	require.NotEmpty(t, len(availability))
+	// File ID 1 is the main movie file
+	availableFile, found := availability[1]
+	require.True(t, found)
+	require.NotEmpty(t, availableFile.Filesize)
+
+	// Add magnet
+	torrentID, err := client.AddMagnet(ctx, nightOfTheLivingDeadMagnet)
+	require.NoError(t, err)
+	fmt.Printf("ID: %v\n", torrentID)
+	require.NotEmpty(t, torrentID)
+
+	// Get torrent info
+	info, err := client.GetTorrentInfo(ctx, torrentID)
+	require.NoError(t, err)
+	fmt.Printf("Torrent info: %+v\n", info)
+	require.NotEmpty(t, info.ID)
+	// Although one or more files of the torrent are instantly available, the torrent info is user-specific.
+	// It's not regarded as downloaded if no file has been selected for download yet.
+	require.Equal(t, "waiting_files_selection", info.Status)
+
+	fileID, err := realdebrid.SelectLargestFile(info)
+	require.NoError(t, err)
+
+	// "Download" file
+	err = client.SelectFiles(ctx, torrentID, fileID)
+	require.NoError(t, err)
+
+	// Get torrent info again.
+	info, err = client.GetTorrentInfo(ctx, torrentID)
+	require.NoError(t, err)
+	fmt.Printf("Torrent info: %+v\n", info)
+	require.NotEmpty(t, info.ID)
+	// This time the torrent is seen as downloaded
+	require.Equal(t, "downloaded", info.Status)
+	require.NotEmpty(t, info.Links)
+
+	// Get HTTP download URL
+	dl, err := client.Unrestrict(ctx, info.Links[0], false)
+	require.NoError(t, err)
+	fmt.Printf("Download: %+v\n", dl)
+	require.NotEmpty(t, dl.Download)
+}

--- a/realdebrid/http.go
+++ b/realdebrid/http.go
@@ -1,0 +1,93 @@
+package realdebrid
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+func (c *Client) get(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create GET request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.auth.KeyOrToken)
+	for headerKey, headerVal := range c.opts.ExtraHeaders {
+		req.Header.Add(headerKey, headerVal)
+	}
+
+	c.logger.Debug("Sending request", zap.String("request", fmt.Sprintf("%+v", req)), zapDebridService)
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't send GET request: %w", err)
+	}
+	defer res.Body.Close()
+	resBody, err := ioutil.ReadAll(res.Body)
+	c.logger.Debug("Got response", zap.Int("status", res.StatusCode), zap.NamedError("bodyReadError", err), zap.ByteString("response", resBody), zapDebridService)
+
+	// Check server response status
+	if res.StatusCode != http.StatusOK {
+		if err, found := errMap[res.StatusCode]; found {
+			return resBody, err
+		}
+		// resBody can be nil if above ioutil.ReadAll failed, but in that case we don't care about the related error.
+		return resBody, fmt.Errorf("bad HTTP response status: %v", res.Status)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read response body: %w", err)
+	}
+	return resBody, nil
+}
+
+func (c *Client) post(ctx context.Context, url string, data url.Values) ([]byte, error) {
+	// RealDebrid asks for the original IP for all POST requests.
+	if c.opts.ForwardOriginIP {
+		if c.auth.IP == "" {
+			return nil, errors.New("auth.IP is empty but client is configured to forward the user's original IP")
+		}
+		data.Add("ip", c.auth.IP)
+	}
+	req, err := http.NewRequest("POST", url, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create POST request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.auth.KeyOrToken)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	for headerKey, headerVal := range c.opts.ExtraHeaders {
+		req.Header.Add(headerKey, headerVal)
+	}
+
+	c.logger.Debug("Sending request", zap.String("request", fmt.Sprintf("%+v", req)), zapDebridService)
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't send POST request: %w", err)
+	}
+	defer res.Body.Close()
+	resBody, err := ioutil.ReadAll(res.Body)
+	c.logger.Debug("Got response", zap.Int("status", res.StatusCode), zap.NamedError("bodyReadError", err), zap.ByteString("response", resBody), zapDebridService)
+
+	// Check server response.
+	// Different RealDebrid API POST endpoints return different status codes.
+	if res.StatusCode != http.StatusCreated &&
+		res.StatusCode != http.StatusNoContent &&
+		res.StatusCode != http.StatusOK {
+		if err, found := errMap[res.StatusCode]; found {
+			return resBody, err
+		}
+		// resBody can be nil if above ioutil.ReadAll failed, but in that case we don't care about the related error.
+		return resBody, fmt.Errorf("bad HTTP response status: %v", res.Status)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read response body: %w", err)
+	}
+	return resBody, nil
+}

--- a/realdebrid/legacy.go
+++ b/realdebrid/legacy.go
@@ -22,7 +22,9 @@ type LegacyClientOptions struct {
 	Timeout      time.Duration
 	CacheAge     time.Duration
 	ExtraHeaders []string
-	// When setting this to true, the user's original IP address is read from the context parameter with the key "debrid_originIP".
+	// When setting this to true, the user's original IP address is read from Auth.IP and forwarded to RealDebrid for all POST requests.
+	// Only required if the library is used in an app on a machine
+	// whose outgoing IP is different from the machine that's going to request the cached file/stream URL.
 	ForwardOriginIP bool
 }
 
@@ -79,15 +81,6 @@ func NewLegacyClient(opts LegacyClientOptions, tokenCache, availabilityCache deb
 		forwardOriginIP:   opts.ForwardOriginIP,
 		logger:            logger,
 	}, nil
-}
-
-// Auth carries authentication/authorization info for RealDebrid.
-type Auth struct {
-	// Long lasting API key or expiring OAuth2 access token
-	KeyOrToken string
-	// The user's original IP. Only required if the library is used in an app on a machine
-	// whose outgoing IP is different from the machine that's going to request the cached file/stream URL.
-	IP string
 }
 
 func (c *LegacyClient) TestToken(ctx context.Context, auth Auth) error {

--- a/realdebrid/types.go
+++ b/realdebrid/types.go
@@ -1,0 +1,123 @@
+package realdebrid
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	// Bad request.
+	// Corresponds to RealDebrid 400 status code.
+	ErrorBadRequest = errors.New("bad request")
+	// Expired, invalid.
+	// Corresponds to RealDebrid 401 status code.
+	ErrorBadToken = errors.New("bad token")
+	// Account locked, not premium.
+	// Corresponds to RealDebrid 403 status code.
+	ErrorPermissionDenied = errors.New("permission denied")
+	// Wrong parameter (invalid file id(s)) / Unknown ressource (invalid id)
+	// Corresponds to RealDebrid 404 status code.
+	ErrorInvalidID = errors.New("invalid ID")
+	// Service unavailable.
+	// Corresponds to RealDebrid 503 status code.
+	ErrorServiceUnavailable = errors.New("service unavailable")
+)
+
+var errMap = map[int]error{
+	400: ErrorBadRequest,
+	401: ErrorBadToken,
+	403: ErrorPermissionDenied,
+	404: ErrorInvalidID,
+	503: ErrorServiceUnavailable,
+}
+
+// User represents a RealDebrid user.
+type User struct {
+	ID       int    `json:"id,omitempty"`
+	Username string `json:"username,omitempty"`
+	Email    string `json:"email,omitempty"`
+	// Fidelity points
+	Points int `json:"points,omitempty"`
+	// User language
+	Locale string `json:"locale,omitempty"`
+	Avatar string `json:"avatar,omitempty"`
+	// "premium" or "free"
+	Type string `json:"type,omitempty"`
+	// seconds left as a Premium user
+	Premium    int       `json:"premium,omitempty"`
+	Expiration time.Time `json:"expiration,omitempty"`
+}
+
+// Download represents an unrestricted link.
+type Download struct {
+	ID       string `json:"id,omitempty"`
+	Filename string `json:"filename,omitempty"`
+	// Mime Type of the file, guessed by the file extension
+	MimeType string `json:"mimeType,omitempty"`
+	// Filesize in bytes, 0 if unknown
+	Filesize int `json:"filesize,omitempty"`
+	// Original link
+	Link string `json:"link,omitempty"`
+	// Host main domain
+	Host string `json:"host,omitempty"`
+	// Max Chunks allowed
+	Chunks int `json:"chunks,omitempty"`
+	// Disable / enable CRC check
+	CRC int `json:"crc,omitempty"`
+	// Generated link
+	Download string `json:"download,omitempty"`
+	// Is the file streamable on website
+	Streamable int `json:"streamable,omitempty"`
+}
+
+// TorrentInfo contains info about a torrent that was added to RealDebrid for a specific user.
+// It contains download info (progress, selected files) after one or more files of the torrent were selected to be downloaded.
+type TorrentInfo struct {
+	ID       string `json:"id,omitempty"`
+	Filename string `json:"filename,omitempty"`
+	// Original name of the torrent
+	OriginalFilename string `json:"original_filename,omitempty"`
+	// SHA1 Hash of the torrent
+	Hash string `json:"hash,omitempty"`
+	// Size of selected files only
+	Bytes int `json:"bytes,omitempty"`
+	// Total size of the torrent
+	OriginalBytes int `json:"original_bytes,omitempty"`
+	// Host main domain
+	Host string `json:"host,omitempty"`
+	// Split size of links
+	Split int `json:"split,omitempty"`
+	// Possible values: 0 to 100
+	Progress int `json:"progress,omitempty"`
+	// Current status of the torrent: magnet_error, magnet_conversion, waiting_files_selection, queued, downloading, downloaded, error, virus, compressing, uploading, dead
+	Status string    `json:"status,omitempty"`
+	Added  time.Time `json:"added,omitempty"`
+	Files  []File    `json:"files,omitempty"`
+	// Host URLs
+	Links []string `json:"links,omitempty"`
+	// !! Only present when finished, jsonDate
+	Ended string `json:"ended,omitempty"`
+	// !! Only present in "downloading", "compressing", "uploading" status
+	Speed int `json:"speed,omitempty"`
+	// !! Only present in "downloading", "magnet_conversion" status
+	Seeders int `json:"seeders,omitempty"`
+}
+
+// File represents a file in a torrent.
+type File struct {
+	ID int `json:"id,omitempty"`
+	// Path to the file inside the torrent, starting with "/"
+	Path  string `json:"path,omitempty"`
+	Bytes int    `json:"bytes,omitempty"`
+	// 0 or 1
+	Selected int `json:"selected,omitempty"`
+}
+
+// InstantAvailability maps torrent file IDs to their availability.
+type InstantAvailability map[int]AvailableFile
+
+// AvailableFile represents an instantly available file.
+type AvailableFile struct {
+	Filename string `json:"filename,omitempty"`
+	Filesize int    `json:"filesize,omitempty"`
+}

--- a/realdebrid/util.go
+++ b/realdebrid/util.go
@@ -1,0 +1,21 @@
+package realdebrid
+
+import "errors"
+
+// SelectLargestFile returns the file ID of the largest file in the torrent.
+func SelectLargestFile(info TorrentInfo) (int, error) {
+	largestID := -1
+	largestSize := 0
+
+	for i, file := range info.Files {
+		if file.Bytes > largestSize {
+			largestID = i
+			largestSize = file.Bytes
+		}
+	}
+	if largestID == -1 {
+		return 0, errors.New("couldn't find largest file in torrent info")
+	}
+
+	return largestID, nil
+}


### PR DESCRIPTION
This PR renames the previous clients to `LegacyClient` and introduces new low-level clients whose methods map to API endpoints of the supported debrid providers (RealDebrid, AllDebrid, Premiumize). It also adds docs about how to work with the three APIs with `cURL`.

The plan for the future is to also replace the `LegacyClient` implementations by a single convenience client that has one simple interface and can be backed by any of the low level clients.